### PR TITLE
Read correct version in yakuza_gmd

### DIFF
--- a/templates/yakuza_gmd.bt
+++ b/templates/yakuza_gmd.bt
@@ -41,12 +41,11 @@ typedef struct
     SetRandomBackColor();
     LittleEndian();
     char Magic[4];      // GSGM
-    u8 Version;         // 2
+    u8 VertEndianness;         // 2 for big, 21 for little
     u8 Endianness;      // 1
     if ( Endianness == 1 ) BigEndian();
     u16 Field06;        // 0
-    u16 Field08;        // 0
-    u16 Field0A;
+    u32 Version;
     u32 FileSize; 
 
     SetRandomBackColor();    


### PR DESCRIPTION
Fields 08 and 0A are supposed to be a u32 which is the actual version. The identifier at offset 0x4 is related to the endianness, although it's only used when reading the vertices, as all other sections use the 1 at 0x5 to check whether to swap the bytes or not.

This is based on this, where `magic` is offset 0x0 and `0x03000B` is the version used in Yakuza 0
![version](https://i.imgur.com/YTCS6wx.png)

And this, where this function is used to byteswap the VertexBuffer section (0x60) after all other sections have been read/byteswapped, regardless of the value of the endianness on `0x5`. `0x21` is used in little endian games (Kiwami 2/Judgment) and `0x2` is used for big endian.
![endianness](https://i.imgur.com/KYOM7uH.png)