### PR TITLE
Use bitfields for material flags in GFD template

### DIFF
--- a/templates/p5_gfd.bt
+++ b/templates/p5_gfd.bt
@@ -4,9 +4,9 @@
 //      File: p5_gfd.bt
 //   Authors: 
 //   Version: 
-//   Purpose: 
-//  Category: 
-// File Mask: 
+//   Purpose: GFD
+//  Category: Persona 5
+// File Mask: *.GAP, *.GMD, *.GFS, *.EPL, *.BED
 //  ID Bytes: GFS0
 //   History: 
 //------------------------------------------------
@@ -71,14 +71,19 @@ typedef enum<u32>
 
  typedef enum<byte>
  {
-     False = 0,
-     True = 1,
+     EBool8_False = 0,
+     EBool8_True = 1,
  } TBool8;
+  typedef enum<u32>
+ {
+     EBool32_False = 0,
+     EBool32_True = 1,
+ } TBool32;
 
 typedef struct
 {
     char Signature[4];
-    u32 Version;
+    u32 Version <format=hex>;
     EFileType Type;
     u32 Reserved;
     Assert( Reserved == 0 );
@@ -340,13 +345,49 @@ typedef enum<u8>
     EMaterialDrawMethod_Translucent = 1,
     EMaterialDrawMethod_BlackAsAlpha = 2,
 } EMaterialDrawMethod;
+typedef struct
+{
+ TBool32 TMaterialFlags_Flag80000000     : 1;
+ TBool32 TMaterialFlags_Flag40000000     : 1;
+ TBool32 TMaterialFlags_Flag20000000Crash: 1;
+ TBool32 TMaterialFlags_HasShadowMap     : 1;
+ TBool32 TMaterialFlags_HasDetailMap     : 1;
+ TBool32 TMaterialFlags_HasNightMap      : 1;
+ TBool32 TMaterialFlags_HasGlowMap       : 1;
+ TBool32 TMaterialFlags_HasHighlightMap  : 1;
+ TBool32 TMaterialFlags_HasReflectionMap : 1;
+ TBool32 TMaterialFlags_HasSpecularMap   : 1;
+ TBool32 TMaterialFlags_HasNormalMap     : 1;
+ TBool32 TMaterialFlags_HasDiffuseMap    : 1;
+ TBool32 TMaterialFlags_DisableBloom     : 1;
+ TBool32 TMaterialFlags_Flag40000Crash   : 1;
+ TBool32 TMaterialFlags_Flag20000Crash   : 1;
+ TBool32 TMaterialFlags_HasAttributes    : 1;
+ TBool32 TMaterialFlags_CastShadow       : 1;
+ TBool32 TMaterialFlags_ReceiveShadow    : 1;
+ TBool32 TMaterialFlags_Flag2000         : 1;
+ TBool32 TMaterialFlags_PurpleWireframe  : 1;
+ TBool32 TMaterialFlags_EnableLight2     : 1;
+ TBool32 TMaterialFlags_Flag400          : 1;
+ TBool32 TMaterialFlags_Flag200          : 1;
+ TBool32 TMaterialFlags_Flag100          : 1;
+ TBool32 TMaterialFlags_EnableLight      : 1;
+ TBool32 TMaterialFlags_Flag40           : 1;
+ TBool32 TMaterialFlags_Flag20           : 1;
+ TBool32 TMaterialFlags_Flag10Crash      : 1;
+ TBool32 TMaterialFlags_Flag8            : 1;
+ TBool32 TMaterialFlags_Flag4            : 1;
+ TBool32 TMaterialFlags_Flag2            : 1;
+ TBool32 TMaterialFlags_Flag1            : 1;
+} TMaterialFlags;
 
 typedef struct(u32 version)
 {
     SetRandomBackColor();
 
     THashString Name( version );
-    EMaterialFlags Flags;
+    local EMaterialFlags Flags;
+	TMaterialFlags MaterialFlags;
     
     if ( version < 0x1104000 )
     {
@@ -406,17 +447,17 @@ typedef struct(u32 version)
         u32 Field98;
     }
 
-    if ( Flags & EMaterialFlags_HasDiffuseMap ) struct TTextureMap DiffuseMap( version );
-    if ( Flags & EMaterialFlags_HasNormalMap ) struct TTextureMap NormalMap( version );
-    if ( Flags & EMaterialFlags_HasSpecularMap  ) struct TTextureMap SpecularMap( version );
-    if ( Flags & EMaterialFlags_HasReflectionMap ) struct TTextureMap ReflectionMap( version );
-    if ( Flags & EMaterialFlags_HasHighlightMap ) struct TTextureMap HighlightMap( version );
-    if ( Flags & EMaterialFlags_HasGlowMap ) struct TTextureMap GlowMap( version );
-    if ( Flags & EMaterialFlags_HasNightMap ) struct TTextureMap NightMap( version );
-    if ( Flags & EMaterialFlags_HasDetailMap ) struct TTextureMap DetailMap( version );
-    if ( Flags & EMaterialFlags_HasShadowMap ) struct TTextureMap ShadowMap( version );
+    if (MaterialFlags.TMaterialFlags_HasDiffuseMap    ) struct TTextureMap DiffuseMap( version );
+    if (MaterialFlags.TMaterialFlags_HasNormalMap     ) struct TTextureMap NormalMap( version );
+    if (MaterialFlags.TMaterialFlags_HasSpecularMap   ) struct TTextureMap SpecularMap( version );
+    if (MaterialFlags.TMaterialFlags_HasReflectionMap ) struct TTextureMap ReflectionMap( version );
+    if (MaterialFlags.TMaterialFlags_HasHighlightMap  ) struct TTextureMap HighlightMap( version );
+    if (MaterialFlags.TMaterialFlags_HasGlowMap       ) struct TTextureMap GlowMap( version );
+    if (MaterialFlags.TMaterialFlags_HasNightMap      ) struct TTextureMap NightMap( version );
+    if (MaterialFlags.TMaterialFlags_HasDetailMap     ) struct TTextureMap DetailMap( version );
+    if (MaterialFlags.TMaterialFlags_HasShadowMap     ) struct TTextureMap ShadowMap( version );
 
-    if ( Flags & EMaterialFlags_HasAttributes )
+    if (MaterialFlags.TMaterialFlags_HasAttributes )
     {
         u32 AttributeCount;
 
@@ -509,7 +550,6 @@ typedef enum<u32>
 {
     EMaterialAttributeFlags_Bit0 = 1 << 0,
 } EMaterialAttributeFlags;
-
 typedef struct
 {
     EMaterialAttributeFlags Flags : 16;

--- a/templates/p5_gfd.bt
+++ b/templates/p5_gfd.bt
@@ -126,7 +126,7 @@ typedef struct(u32 version)
         char Str[Length];  
     
         if ( version >= 0x01105100 )
-            SeekCurrent( 1 ); // padding byte
+            FSeek( FTell() + 1 ); // padding byte
         
         if ( version > 0x1080000 )
         {
@@ -2944,7 +2944,8 @@ typedef struct( u32 version )
 //
 // == Physics Data Chunk type stuff --
 //
-typedef struct{
+typedef struct
+{
 	u32 Field140;
 	f32 Field13C;
 	f32 Field138;
@@ -2955,7 +2956,8 @@ typedef struct{
 	u32 Entry3Count;
 } TChunkTypePhysicsDictionaryHeader <name="PhysicsDictionaryHeader">;
 
-typedef struct{
+typedef struct( u32 version )
+{
 	f32 Field34;
 	f32 Field38;
 	f32 Field3C;
@@ -2963,7 +2965,7 @@ typedef struct{
 	TBool8 hasName;
 	if (hasName > 0)
 	{
-		THashString Name( 0x01105070 );
+		THashString Name( version );
 	}
 	else{
 		f32 Field18;
@@ -2973,7 +2975,8 @@ typedef struct{
 	
 }TEntryType1<name = "Type 1 Entry">;
 
-typedef struct{
+typedef struct( u32 version )
+{
 	u16 Field94;
 	f32 field84;
 	if (Field94 == 1)
@@ -2984,7 +2987,7 @@ typedef struct{
 	TBool8 hasName;
 	if (hasName > 0)
 	{
-		THashString Name( 0x01105070 );
+		THashString Name( version );
 	}
 }TEntryType2<name = "Type 2 Entry">;
 
@@ -2997,24 +3000,24 @@ typedef struct{
 	u16 childBone;
 }TEntryType3<name = "Type 3 Entry">;
 
-typedef struct(u32 count) {
-	local u32 i;
+typedef struct(u32 count, u32 version) {
+	local u32 i<hidden=true>;
 	for (i = 0; i < count; i++)
 	{
-		TEntryType1 entryType1<read=NameToStringT1>;
+		TEntryType1 entryType1(version)<read=NameToStringT1>;
 	}
 }TEntryType1Wrapper;
 
-typedef struct(u32 count) {
-	local u32 i;
+typedef struct(u32 count, u32 version) {
+	local u32 i<hidden=true>;
 	for (i = 0; i < count; i++)
 	{
-		TEntryType2 entryType2<read=NameToStringT2>;
+		TEntryType2 entryType2(version)<read=NameToStringT2>;
 	}
 }TEntryType2Wrapper;
 
 typedef struct(u32 count) {
-	local u32 i;
+	local u32 i<hidden=true>;
 	for (i = 0; i < count; i++)
 	{
 		TEntryType3 entryType3;
@@ -3053,8 +3056,8 @@ typedef struct
 
     TChunkHeader ChunkHeader;
     TChunkTypePhysicsDictionaryHeader Header;
-    TEntryType1Wrapper Type1Entries(Header.Entry1Count)<name = "Entry Type 1 List">;
-    TEntryType2Wrapper Type2Entries(Header.Entry2Count)<name = "Entry Type 2 List">;
+    TEntryType1Wrapper Type1Entries(Header.Entry1Count, ChunkHeader.Version)<name = "Entry Type 1 List">;
+    TEntryType2Wrapper Type2Entries(Header.Entry2Count, ChunkHeader.Version)<name = "Entry Type 2 List">;
     TEntryType3Wrapper Type3Entries(Header.Entry3Count)<name = "Entry Type 3 List">;
 } TPhysicsDictionary <optimize=false>;
 //

--- a/templates/p5_gfd.bt
+++ b/templates/p5_gfd.bt
@@ -73,7 +73,7 @@ typedef enum<u32>
  {
      False = 0,
      True = 1,
- } TrueFalse;
+ } TBool8;
 
 typedef struct
 {
@@ -125,8 +125,8 @@ typedef struct(u32 version)
     {
         char Str[Length];  
     
-        /*if ( version >= 0x01105100 )
-            SeekCurrent( 1 ); // padding byte*/
+        if ( version >= 0x01105100 )
+            SeekCurrent( 1 ); // padding byte
         
         if ( version > 0x1080000 )
         {
@@ -462,7 +462,7 @@ typedef struct( u32 version )
     THashString Name( version );
     s32 Field44;
     u8 Field48;
-    TrueFalse HasTextureFiltering <name = "Has Texture Filtering">;
+    TBool8 HasTextureFiltering <name = "Has Texture Filtering">;
     u8 Field4A;
     u8 Field4B;
     f32 Field4C;
@@ -2945,33 +2945,30 @@ typedef struct( u32 version )
 // == Physics Data Chunk type stuff --
 //
 typedef struct{
-	u32 unk;
-	f32 unk;
-	f32 unk;
-	f32 unk;
-	f32 unk;
-	u32 entry1count;
-	u32 entry2count;
-	u32 entry3count;
+	u32 Field140;
+	f32 Field13C;
+	f32 Field138;
+	f32 Field134;
+	f32 Field130;
+	u32 Entry1Count;
+	u32 Entry2Count;
+	u32 Entry3Count;
 } TChunkTypePhysicsDictionaryHeader <name="PhysicsDictionaryHeader">;
 
 typedef struct{
-	f32 field34;
-	f32 field38;
-	f32 field3C;
-	f32 field40;
-	byte hasName;
+	f32 Field34;
+	f32 Field38;
+	f32 Field3C;
+	f32 Field40;
+	TBool8 hasName;
 	if (hasName > 0)
 	{
-		byte unk<hidden = true>;
-		byte nameSize;
-		char boneName[nameSize];
-		u32 stringHash<format=hex>;
+		THashString Name( 0x01105070 );
 	}
 	else{
-		f32 field18;
-		f32 field14;
-		f32 field10;
+		f32 Field18;
+		f32 Field14;
+		f32 Field10;
 	}
 	
 }TEntryType1<name = "Type 1 Entry">;
@@ -2984,13 +2981,10 @@ typedef struct{
 		f32 Field88;
 	}
 	TMatrix4x4 Field8C;
-	byte hasName;
+	TBool8 hasName;
 	if (hasName > 0)
 	{
-		byte unk<hidden = true>;
-		byte nameSize;
-		char boneName[nameSize];
-		u32 stringHash<format=hex>;
+		THashString Name( 0x01105070 );
 	}
 }TEntryType2<name = "Type 2 Entry">;
 
@@ -3032,7 +3026,8 @@ string NameToStringT1( TEntryType1& value )
     string buffer;
 	if (value.hasName > 0)
 	{
-		buffer = value.boneName;
+		SPrintf( buffer, "%s", THashStringToString( value.Name ) );
+		return buffer;
 	}
 	else buffer = "null";
 	
@@ -3044,7 +3039,8 @@ string NameToStringT2( TEntryType2& value )
     string buffer;
 	if (value.hasName > 0)
 	{
-		buffer = value.boneName;
+		SPrintf( buffer, "%s", THashStringToString( value.Name ) );
+		return buffer;
 	}
 	else buffer = "null";
 	
@@ -3057,9 +3053,9 @@ typedef struct
 
     TChunkHeader ChunkHeader;
     TChunkTypePhysicsDictionaryHeader Header;
-    TEntryType1Wrapper Type1Entries(Header.entry1count)<name = "Entry Type 1 List">;
-    TEntryType2Wrapper Type2Entries(Header.entry2count)<name = "Entry Type 2 List">;
-    TEntryType3Wrapper Type3Entries(Header.entry3count)<name = "Entry Type 3 List">;
+    TEntryType1Wrapper Type1Entries(Header.Entry1Count)<name = "Entry Type 1 List">;
+    TEntryType2Wrapper Type2Entries(Header.Entry2Count)<name = "Entry Type 2 List">;
+    TEntryType3Wrapper Type3Entries(Header.Entry3Count)<name = "Entry Type 3 List">;
 } TPhysicsDictionary <optimize=false>;
 //
 // -- Physics Data Chunk End --
@@ -3120,12 +3116,12 @@ typedef struct
                 struct TAnimationPack AnimationPack;
                 break;
 
-            case EChunkType_EOF:
-                struct TEOFChunk EOF;
-                break;
-				
 			case EChunkType_PhysicsDictionary:
                 struct TPhysicsDictionary PhysicsChunkType;
+                break;
+
+            case EChunkType_EOF:
+                struct TEOFChunk EOF;
                 break;
 
             default:

--- a/templates/p5_gfd.bt
+++ b/templates/p5_gfd.bt
@@ -1,13 +1,13 @@
 //------------------------------------------------
 //--- 010 Editor v8.0 Binary Template
 //
-//      File: 
+//      File: p5_gfd.bt
 //   Authors: 
 //   Version: 
 //   Purpose: 
 //  Category: 
 // File Mask: 
-//  ID Bytes: 
+//  ID Bytes: GFS0
 //   History: 
 //------------------------------------------------
 
@@ -42,7 +42,7 @@ typedef enum<u32>
     EFileType_MorphTarget,
     EFileType_MorphTargetList,
     EFileType_MaterialDictionary,
-    EFileType_ChunkType000100F9,
+    EFileType_PhysicsDictionary,
     EFileType_ChunkType000100F8,
     EFileType_AnimationPack,
     EFileType_MaterialAttribute,
@@ -63,11 +63,17 @@ typedef enum<u32>
     EChunkType_EOF = 0,
     EChunkType_Model              = 0x00010003,
     EChunkType_ChunkType000100F8  = 0x000100F8,
-    EChunkType_ChunkType000100F9  = 0x000100F9,
+    EChunkType_PhysicsDictionary  = 0x000100F9,
     EChunkType_MaterialDictionary = 0x000100FB,
     EChunkType_TextureDictionary  = 0x000100FC,
     EChunkType_AnimationPack      = 0x000100FD
 } EChunkType;
+
+ typedef enum<byte>
+ {
+     False = 0,
+     True = 1,
+ } TrueFalse;
 
 typedef struct
 {
@@ -119,8 +125,8 @@ typedef struct(u32 version)
     {
         char Str[Length];  
     
-        if ( version >= 0x01105100 )
-            FSeek( FTell() + 1 ); // padding byte
+        /*if ( version >= 0x01105100 )
+            SeekCurrent( 1 ); // padding byte*/
         
         if ( version > 0x1080000 )
         {
@@ -236,7 +242,8 @@ typedef enum<u16>
 {
     ETextureFormat_Invalid = 0,
     ETextureFormat_DDS = 1,
-    ETextureFormat_GXT = 6
+    ETextureFormat_GXT = 6,
+    ETextureFormat_GNF = 9
 } ETextureFormat;
 
 typedef struct
@@ -331,6 +338,7 @@ typedef enum<u8>
 {
     EMaterialDrawMethod_Opaque = 0,
     EMaterialDrawMethod_Translucent = 1,
+    EMaterialDrawMethod_BlackAsAlpha = 2,
 } EMaterialDrawMethod;
 
 typedef struct(u32 version)
@@ -394,11 +402,7 @@ typedef struct(u32 version)
     u32 Field6C;
     u32 Field70;
     s16 Field50;
-    
-    if ( version <= 0x1105070 || version >= 0x1105090 )
-    {
-        u32 Field98;
-    }
+	u32 Field98;
 
     if ( Flags & EMaterialFlags_HasDiffuseMap ) struct TTextureMap DiffuseMap( version );
     if ( Flags & EMaterialFlags_HasNormalMap ) struct TTextureMap NormalMap( version );
@@ -435,7 +439,9 @@ typedef struct(u32 version)
                 case EMaterialAttributeType_Type7: struct TMaterialAttributeType7 Attribute( version ); break;
                 case EMaterialAttributeType_Type8: struct TMaterialAttributeType8 Attribute( version ); break;
                 default:
-                    Assert( false, "Unknown material attribute type" );
+                    local string buffer;
+                    SPrintf( buffer, "Unknown material attribute type %01d", ( attributeHeader & 0xFFFF ) );
+                    Assert( false, buffer );
                     break;
             }
         }
@@ -456,7 +462,7 @@ typedef struct( u32 version )
     THashString Name( version );
     s32 Field44;
     u8 Field48;
-    u8 Field49;
+    TrueFalse HasTextureFiltering <name = "Has Texture Filtering">;
     u8 Field4A;
     u8 Field4B;
     f32 Field4C;
@@ -1441,6 +1447,8 @@ typedef enum<u32>
     EKeyType_Type31 = 31,
     EKeyType_NodeRHalf = 32,
     EKeyType_NodeSHalf = 33,
+	EKeyType_34P5R = 34,
+	EKeyType_35P5R = 35,
 } EKeyType;
 
 typedef struct( u32 version )
@@ -1518,18 +1526,27 @@ typedef struct( u32 version )
                     }
                 }
                 break;
+				
+			// P5R keys
+			case 34: struct TKeyType34P5R Keys [ KeyCount ]; break;
+			//case 34: byte UnkKeyType [ KeyCount*12 ]; break;
+			case 35: struct TKeyType35P5R Keys [ KeyCount ]; break;
+			
             default:
-                Assert( false, "Unknown/Invalid Key frame type" );
+			    local string buffer;
+                SPrintf( buffer, "Unknown/Invalid Key frame type %01d", KeyType );
+                Assert( false, buffer );
         }
         
-        // Read scale values for compressed keys
+         // Read scale values for compressed keys
         if ( KeyType == EKeyType_NodePRHalf   || KeyType == EKeyType_NodePRSHalf ||
              KeyType == EKeyType_NodePRHalf_2 || KeyType == EKeyType_Type31 ||
-             KeyType == EKeyType_NodeRHalf    || KeyType == EKeyType_NodeSHalf )
+             KeyType == EKeyType_NodeRHalf    || KeyType == EKeyType_NodeSHalf || 
+			 KeyType == EKeyType_34P5R        || KeyType == EKeyType_35P5R      )
         {
             TVector3 PositionScale;
             
-            if ( version < 0x01105100 || KeyType != EKeyType_Type31 )
+            if ( version < 0x01105100 || KeyType != EKeyType_Type31)
                 TVector3 ScaleScale;
         }
     }
@@ -1613,6 +1630,18 @@ typedef struct
 {
     TVector3Half Position;
 } TKeyType31Dancing;
+
+typedef struct
+{
+    TVector3Half Position;
+	TVector3Half Scale;
+} TKeyType34P5R;
+
+typedef struct
+{
+    TQuaternionHalf Rotation;
+    TVector3Half Scale;
+} TKeyType35P5R;
 
 typedef struct
 {
@@ -2912,6 +2941,130 @@ typedef struct( u32 version )
 // -- Model pack types --
 //
 
+//
+// == Physics Data Chunk type stuff --
+//
+typedef struct{
+	u32 unk;
+	f32 unk;
+	f32 unk;
+	f32 unk;
+	f32 unk;
+	u32 entry1count;
+	u32 entry2count;
+	u32 entry3count;
+} TChunkTypePhysicsDictionaryHeader <name="PhysicsDictionaryHeader">;
+
+typedef struct{
+	f32 field34;
+	f32 field38;
+	f32 field3C;
+	f32 field40;
+	byte hasName;
+	if (hasName > 0)
+	{
+		byte unk<hidden = true>;
+		byte nameSize;
+		char boneName[nameSize];
+		u32 stringHash<format=hex>;
+	}
+	else{
+		f32 field18;
+		f32 field14;
+		f32 field10;
+	}
+	
+}TEntryType1<name = "Type 1 Entry">;
+
+typedef struct{
+	u16 Field94;
+	f32 field84;
+	if (Field94 == 1)
+	{
+		f32 Field88;
+	}
+	TMatrix4x4 Field8C;
+	byte hasName;
+	if (hasName > 0)
+	{
+		byte unk<hidden = true>;
+		byte nameSize;
+		char boneName[nameSize];
+		u32 stringHash<format=hex>;
+	}
+}TEntryType2<name = "Type 2 Entry">;
+
+typedef struct{
+	f32 Field00;
+	f32 Field04;
+	
+	f32 field08;
+	u16 parentBone;
+	u16 childBone;
+}TEntryType3<name = "Type 3 Entry">;
+
+typedef struct(u32 count) {
+	local u32 i;
+	for (i = 0; i < count; i++)
+	{
+		TEntryType1 entryType1<read=NameToStringT1>;
+	}
+}TEntryType1Wrapper;
+
+typedef struct(u32 count) {
+	local u32 i;
+	for (i = 0; i < count; i++)
+	{
+		TEntryType2 entryType2<read=NameToStringT2>;
+	}
+}TEntryType2Wrapper;
+
+typedef struct(u32 count) {
+	local u32 i;
+	for (i = 0; i < count; i++)
+	{
+		TEntryType3 entryType3;
+	}
+}TEntryType3Wrapper;
+
+string NameToStringT1( TEntryType1& value )
+{
+    string buffer;
+	if (value.hasName > 0)
+	{
+		buffer = value.boneName;
+	}
+	else buffer = "null";
+	
+	return buffer;
+}
+
+string NameToStringT2( TEntryType2& value )
+{
+    string buffer;
+	if (value.hasName > 0)
+	{
+		buffer = value.boneName;
+	}
+	else buffer = "null";
+	
+	return buffer;
+}
+
+typedef struct
+{
+    SetRandomBackColor();
+
+    TChunkHeader ChunkHeader;
+    TChunkTypePhysicsDictionaryHeader Header;
+    TEntryType1Wrapper Type1Entries(Header.entry1count)<name = "Entry Type 1 List">;
+    TEntryType2Wrapper Type2Entries(Header.entry2count)<name = "Entry Type 2 List">;
+    TEntryType3Wrapper Type3Entries(Header.entry3count)<name = "Entry Type 3 List">;
+} TPhysicsDictionary <optimize=false>;
+//
+// -- Physics Data Chunk End --
+//
+
 typedef struct
 {
     SetRandomBackColor();
@@ -2969,6 +3122,10 @@ typedef struct
 
             case EChunkType_EOF:
                 struct TEOFChunk EOF;
+                break;
+				
+			case EChunkType_PhysicsDictionary:
+                struct TPhysicsDictionary PhysicsChunkType;
                 break;
 
             default:

--- a/templates/p5_gfd.bt
+++ b/templates/p5_gfd.bt
@@ -6,7 +6,7 @@
 //   Version: 
 //   Purpose: GFD
 //  Category: Persona 5
-// File Mask: *.GAP, *.GMD, *.GFS, *.EPL, *.BED
+// File Mask: *.gmd, *.gap, *.epl, *.bed, *.gfs
 //  ID Bytes: GFS0
 //   History: 
 //------------------------------------------------

--- a/templates/p5_gfd.bt
+++ b/templates/p5_gfd.bt
@@ -402,7 +402,9 @@ typedef struct(u32 version)
     u32 Field6C;
     u32 Field70;
     s16 Field50;
-	u32 Field98;
+    {
+        u32 Field98;
+    }
 
     if ( Flags & EMaterialFlags_HasDiffuseMap ) struct TTextureMap DiffuseMap( version );
     if ( Flags & EMaterialFlags_HasNormalMap ) struct TTextureMap NormalMap( version );


### PR DESCRIPTION
before now the GFD template was using just a normal int value for the material flags, so i decided to turn it into a u32 bitfield for ease of editing