### PR TITLE
fixed some dutch epl coding + stuff

### DIFF
--- a/templates/p5_gfd.bt
+++ b/templates/p5_gfd.bt
@@ -1877,7 +1877,7 @@ typedef struct( u32 version )
 
     struct TEplLeafCommonData6 Field10;
     struct TEplLeafCommonData6 Field74;
-    struct TEplLeafCommonData6 FieldD8;
+    struct TEplLeafCommonData5 FieldD8;
     struct TEplParticleEmitter Field140(version, Type);
     bool HasEmbeddedFile;
 

--- a/templates/p5_gfd.bt
+++ b/templates/p5_gfd.bt
@@ -71,8 +71,8 @@ typedef struct(u32 version)
     {
         char Str[Length];  
     
-        if ( version >= 0x01105100 )
-            FSeek( FTell() + 1 ); // padding byte
+        //if ( version >= 0x01105100 )
+            //FSeek( FTell() + 1 ); // padding byte
         
         if ( version > 0x1080000 )
         {
@@ -1058,7 +1058,7 @@ typedef struct( u32 version )
     {
         struct TEpl Epl( version );
         THashString Field04( version );
-    } Entries( version )[ Count ];
+    } Entries( version )[ Count ] <optimize=false>;
 } TAnimationFlagsFlag10000000Data <optimize=false>;
 
 typedef struct( u32 version )
@@ -1843,7 +1843,7 @@ typedef struct( u32 version )
 // verified
 typedef struct( u32 version )
 {
-    struct TEplLeafSharedData5 Field64;
+    struct TEplLeafCommonData5 Field64;
     TVector2 FieldB8;
     TVector2 FieldC0;
     f32 FieldC8;
@@ -1875,10 +1875,10 @@ typedef struct( u32 version )
     if ( version > 0x1104170 )
         f32 Field138;
 
-    struct TEplLeafSharedData6 Field10;
-    struct TEplLeafSharedData6 Field74;
-    struct TEplLeafSharedData6 FieldD8;
-    struct TEplParticleEmitter Field140;
+    struct TEplLeafCommonData6 Field10;
+    struct TEplLeafCommonData6 Field74;
+    struct TEplLeafCommonData6 FieldD8;
+    struct TEplParticleEmitter Field140(version, Type);
     bool HasEmbeddedFile;
 
     if ( HasEmbeddedFile )
@@ -2913,5 +2913,5 @@ else if ( Stricmp( fileExt, ".BFL" ) == 0 )
 //}
 else
 {
-    TModelPackFile File;
+    TModelPackFile File <optimize=false>;
 }

--- a/templates/p5_gfd.bt
+++ b/templates/p5_gfd.bt
@@ -67,16 +67,16 @@ string TStringToString( TString& value )
 typedef struct(u32 version)
 {
     u16 Length;
-
     if ( Length )
     {
-        char Str[Length]; 
+        char Str[Length];  
     
         if ( version >= 0x01105100 )
             FSeek( FTell() + 1 ); // padding byte
         
         if ( version > 0x1080000 )
         {
+            // hash
             u32 Hash;
         }   
     }  
@@ -225,38 +225,38 @@ typedef struct
 
 typedef struct
 {
- TBool32 TMaterialFlags_Flag80000000     : 1;
- TBool32 TMaterialFlags_Flag40000000     : 1;
- TBool32 TMaterialFlags_Flag20000000Crash: 1;
- TBool32 TMaterialFlags_HasShadowMap     : 1;
- TBool32 TMaterialFlags_HasDetailMap     : 1;
- TBool32 TMaterialFlags_HasNightMap      : 1;
- TBool32 TMaterialFlags_HasGlowMap       : 1;
- TBool32 TMaterialFlags_HasHighlightMap  : 1;
- TBool32 TMaterialFlags_HasReflectionMap : 1;
- TBool32 TMaterialFlags_HasSpecularMap   : 1;
- TBool32 TMaterialFlags_HasNormalMap     : 1;
- TBool32 TMaterialFlags_HasDiffuseMap    : 1;
- TBool32 TMaterialFlags_DisableBloom     : 1;
- TBool32 TMaterialFlags_Flag40000Crash   : 1;
- TBool32 TMaterialFlags_HasOutline       : 1;
- TBool32 TMaterialFlags_HasAttributes    : 1;
- TBool32 TMaterialFlags_CastShadow       : 1;
- TBool32 TMaterialFlags_ReceiveShadow    : 1;
- TBool32 TMaterialFlags_Flag2000         : 1;
- TBool32 TMaterialFlags_PurpleWireframe  : 1;
- TBool32 TMaterialFlags_EnableLight2     : 1;
- TBool32 TMaterialFlags_Flag400          : 1;
- TBool32 TMaterialFlags_Flag200          : 1;
- TBool32 TMaterialFlags_Flag100          : 1;
- TBool32 TMaterialFlags_EnableLight      : 1;
- TBool32 TMaterialFlags_Flag40           : 1;
- TBool32 TMaterialFlags_Flag20           : 1;
- TBool32 TMaterialFlags_Flag10Crash      : 1;
- TBool32 TMaterialFlags_Flag8            : 1;
- TBool32 TMaterialFlags_Flag4            : 1;
- TBool32 TMaterialFlags_Flag2            : 1;
- TBool32 TMaterialFlags_Flag1            : 1;
+    TBool32 TMaterialFlags_Bit31            : 1;
+    TBool32 TMaterialFlags_Bit30            : 1;
+    TBool32 TMaterialFlags_Bit29            : 1;
+    TBool32 TMaterialFlags_HasShadowMap     : 1;
+    TBool32 TMaterialFlags_HasDetailMap     : 1;
+    TBool32 TMaterialFlags_HasNightMap      : 1;
+    TBool32 TMaterialFlags_HasGlowMap       : 1;
+    TBool32 TMaterialFlags_HasHighlightMap  : 1;
+    TBool32 TMaterialFlags_HasReflectionMap : 1;
+    TBool32 TMaterialFlags_HasSpecularMap   : 1;
+    TBool32 TMaterialFlags_HasNormalMap     : 1;
+    TBool32 TMaterialFlags_HasDiffuseMap    : 1;
+    TBool32 TMaterialFlags_DisableBloom     : 1;
+    TBool32 TMaterialFlags_Bit18            : 1;
+    TBool32 TMaterialFlags_HasOutline       : 1;
+    TBool32 TMaterialFlags_HasAttributes    : 1;
+    TBool32 TMaterialFlags_CastShadow       : 1;
+    TBool32 TMaterialFlags_ReceiveShadow    : 1;
+    TBool32 TMaterialFlags_Bit13            : 1;
+    TBool32 TMaterialFlags_PurpleWireframe  : 1;
+    TBool32 TMaterialFlags_EnableLight2     : 1;
+    TBool32 TMaterialFlags_Bit10            : 1;
+    TBool32 TMaterialFlags_Bit9             : 1;
+    TBool32 TMaterialFlags_Bit8             : 1;
+    TBool32 TMaterialFlags_EnableLight      : 1;
+    TBool32 TMaterialFlags_Bit6             : 1;
+    TBool32 TMaterialFlags_Bit5             : 1;
+    TBool32 TMaterialFlags_HasVertexColors  : 1;
+    TBool32 TMaterialFlags_Bit3             : 1;
+    TBool32 TMaterialFlags_Bit2             : 1;
+    TBool32 TMaterialFlags_Bit1             : 1;
+    TBool32 TMaterialFlags_Bit0             : 1;
 } TMaterialFlags;
 
 typedef struct
@@ -334,7 +334,7 @@ typedef struct(u32 version)
     s16 Field5C;
     TMaterialMapsTexcoord TexcoordFlags;
     TMaterialMapsTexcoord TexcoordFlags;
-    s16 Field50;
+    TBool16 DisableBackfaceCulling;
     {
         u32 Field98<format=hex>;
     }
@@ -365,10 +365,10 @@ typedef struct(u32 version)
             switch ( ( enum EMaterialAttributeType )( attributeHeader & 0xFFFF ) )
             {
                 case EMaterialAttributeType_ToonShading: struct TMaterialAttributeToonShading Attribute( version ); break;
-                case EMaterialAttributeType_Type1: struct TMaterialAttributeType1 Attribute( version ); break;
+                case EMaterialAttributeType_InnerGlow: struct TMaterialAttributeInnerGlow Attribute( version ); break;
                 case EMaterialAttributeType_Outline: struct TMaterialAttributeOutline Attribute( version ); break;
                 case EMaterialAttributeType_Type3: struct TMaterialAttributeType3 Attribute( version ); break;
-                case EMaterialAttributeType_Type4: struct TMaterialAttributeType4 Attribute( version ); break;
+                case EMaterialAttributeType_Type4: struct TMaterialAttributeScrollingTexture Attribute( version ); break;
                 case EMaterialAttributeType_Type5: struct TMaterialAttributeType5 Attribute( version ); break;
                 case EMaterialAttributeType_Type6: struct TMaterialAttributeType6 Attribute( version ); break;
                 case EMaterialAttributeType_Type7: struct TMaterialAttributeType7 Attribute( version ); break;
@@ -533,7 +533,7 @@ typedef struct(u32 version)
     SetBackColorToShadeOfLastColor( 0x10 );
 
     TMaterialAttributeHeader Header;
-    Assert( Header.Type == EMaterialAttributeType_Type1 );
+    Assert( Header.Type == EMaterialAttributeType_InnerGlow );
 
     TVector4 Field0C;
     f32 Field1C;
@@ -544,38 +544,38 @@ typedef struct(u32 version)
 
     if ( version <= 0x1104500 )
     {
-        local EMaterialAttributeType1Flags Flags;
+        local EMaterialAttributeInnerGlowFlags Flags;
 
         bool Flag1;
         if ( Flag1 )
-            Flags |= EMaterialAttributeType1Flags_Bit0;
+            Flags |= EMaterialAttributeInnerGlowFlags_Bit0;
 
         if ( version > 0x1104180 )
         {
             bool Flag2;
             if ( Flag2 )
-                Flags |= EMaterialAttributeType1Flags_Bit1;
+                Flags |= EMaterialAttributeInnerGlowFlags_Bit1;
         }
 
         if ( version > 0x1104210 )
         {
             bool Flag4;
             if ( Flag4 )
-                Flags |= EMaterialAttributeType1Flags_Bit2;
+                Flags |= EMaterialAttributeInnerGlowFlags_Bit2;
         }
 
         if ( Version > 0x1104400 )
         {
             bool Flag8;
             if ( Flag8 )
-                Flags |= EMaterialAttributeType1Flags_Bit3;
+                Flags |= EMaterialAttributeInnerGlowFlags_Bit3;
         }
     }
     else
     {
-        EMaterialAttributeType1Flags Flags;
+        EMaterialAttributeInnerGlowFlags Flags;
     }
-} TMaterialAttributeType1 <optimize=false>;
+} TMaterialAttributeInnerGlow <optimize=false>;
 
 typedef struct(u32 version)
 {
@@ -584,7 +584,7 @@ typedef struct(u32 version)
     TMaterialAttributeHeader Header;
     Assert( Header.Type == EMaterialAttributeType_Outline );
 
-    s32 Type;
+    s32 Category;
     s32 Color;
 } TMaterialAttributeOutline;
 
@@ -632,7 +632,7 @@ typedef struct(u32 version)
     f32 Field54;
     f32 Field58;
     s32 Field5C;
-} TMaterialAttributeType4;
+} TMaterialAttributeScrollingTexture;
 
 typedef struct(u32 version)
 {
@@ -1058,7 +1058,7 @@ typedef struct( u32 version )
     {
         struct TEpl Epl( version );
         THashString Field04( version );
-    } Entries( version )[ Count ] <optimize=false>;
+    } Entries( version )[ Count ];
 } TAnimationFlagsFlag10000000Data <optimize=false>;
 
 typedef struct( u32 version )
@@ -2508,10 +2508,10 @@ typedef struct
 
 typedef struct( u32 version )
 {
-	f32 Field34;
+	f32 MotionScale;
 	f32 Field38;
 	f32 Field3C;
-	f32 Field40;
+	f32 SpringRate;
 	TBool8 hasName;
 	if (hasName > 0)
 	{
@@ -2523,15 +2523,15 @@ typedef struct( u32 version )
 		f32 Field10;
 	}
 	
-}TEntryType1<name = "Type 1 Entry">;
+}TEntryType1<name = "Bone Dictionary">;
 
 typedef struct( u32 version )
 {
-	u16 Field94;
-	f32 field84;
-	if (Field94 == 1)
+	u16 CapsuleType;
+	f32 CapsuleRadius;
+	if (CapsuleType == 1)
 	{
-		f32 Field88;
+		f32 CapsuleHeight;
 	}
 	TMatrix4x4 Field8C;
 	TBool8 hasName;
@@ -2539,16 +2539,16 @@ typedef struct( u32 version )
 	{
 		THashString Name( version );
 	}
-}TEntryType2<name = "Type 2 Entry">;
+}TEntryType2<name = "Collision Capsules">;
 
 typedef struct{
-	f32 Field00;
+	f32 Gravity;
 	f32 Field04;
 	
-	f32 field08;
+	f32 BoneThickness;
 	u16 parentBone;
 	u16 childBone;
-}TEntryType3<name = "Type 3 Entry">;
+}TEntryType3<name = "Bone Collections">;
 
 typedef struct(u32 count, u32 version) {
 	local u32 i<hidden=true>;
@@ -2606,9 +2606,9 @@ typedef struct
 
     TChunkHeader ChunkHeader;
     TChunkTypePhysicsDictionaryHeader Header;
-    TEntryType1Wrapper Type1Entries(Header.Entry1Count, ChunkHeader.Version)<name = "Entry Type 1 List">;
-    TEntryType2Wrapper Type2Entries(Header.Entry2Count, ChunkHeader.Version)<name = "Entry Type 2 List">;
-    TEntryType3Wrapper Type3Entries(Header.Entry3Count)<name = "Entry Type 3 List">;
+    TEntryType1Wrapper Type1Entries(Header.Entry1Count, ChunkHeader.Version)<name = "Bone Dictionary List">;
+    TEntryType2Wrapper Type2Entries(Header.Entry2Count, ChunkHeader.Version)<name = "Collision Capsules List">;
+    TEntryType3Wrapper Type3Entries(Header.Entry3Count)<name = "Bone Collections List">;
 } TPhysicsDictionary <optimize=false>;
 //
 // -- Physics Data Chunk End --
@@ -2913,5 +2913,5 @@ else if ( Stricmp( fileExt, ".BFL" ) == 0 )
 //}
 else
 {
-    TModelPackFile File <optimize=false>;
+    TModelPackFile File;
 }

--- a/templates/p5_gfd_enums.bt
+++ b/templates/p5_gfd_enums.bt
@@ -4,6 +4,12 @@ typedef enum<byte>
     EBool8_True = 1,
 } TBool8;
 
+typedef enum<u16>
+{
+    EBool16_False = 0,
+    EBool16_True = 1,
+} TBool16;
+
 typedef enum<u32>
 {
     EBool32_False = 0,
@@ -85,25 +91,25 @@ typedef enum<u32>
 
 typedef enum<u32>
 {
-    EMaterialFlags_Flag1            = 1 << 0,
-    EMaterialFlags_Flag2            = 1 << 1,
-    EMaterialFlags_Flag4            = 1 << 2,
-    EMaterialFlags_Flag8            = 1 << 3,
-    EMaterialFlags_Flag10Crash      = 1 << 4,
-    EMaterialFlags_Flag20           = 1 << 5,
-    EMaterialFlags_Flag40           = 1 << 6,
+    EMaterialFlags_Bit0             = 1 << 0,
+    EMaterialFlags_Bit1             = 1 << 1,
+    EMaterialFlags_Bit2             = 1 << 2,
+    EMaterialFlags_Bit3             = 1 << 3,
+    EMaterialFlags_HasVertexColors  = 1 << 4,
+    EMaterialFlags_Bit5             = 1 << 5,
+    EMaterialFlags_Bit6             = 1 << 6,
     EMaterialFlags_EnableLight      = 1 << 7,
-    EMaterialFlags_Flag100          = 1 << 8,
-    EMaterialFlags_Flag200          = 1 << 9,
-    EMaterialFlags_Flag400          = 1 << 10,
+    EMaterialFlags_Bit8             = 1 << 8,
+    EMaterialFlags_Bit9             = 1 << 9,
+    EMaterialFlags_Bit10            = 1 << 10,
     EMaterialFlags_EnableLight2     = 1 << 11,
     EMaterialFlags_PurpleWireframe  = 1 << 12,
-    EMaterialFlags_Flag2000         = 1 << 13,
+    EMaterialFlags_Bit13            = 1 << 13,
     EMaterialFlags_ReceiveShadow    = 1 << 14,
     EMaterialFlags_CastShadow       = 1 << 15,
     EMaterialFlags_HasAttributes    = 1 << 16,
-    TMaterialFlags_HasOutline       = 1 << 17,
-    EMaterialFlags_Flag40000Crash   = 1 << 18,
+    EMaterialFlags_HasOutline       = 1 << 17,
+    EMaterialFlags_Bit18            = 1 << 18,
     EMaterialFlags_DisableBloom     = 1 << 19,
     EMaterialFlags_HasDiffuseMap    = 1 << 20,
     EMaterialFlags_HasNormalMap     = 1 << 21,
@@ -114,9 +120,9 @@ typedef enum<u32>
     EMaterialFlags_HasNightMap      = 1 << 26,
     EMaterialFlags_HasDetailMap     = 1 << 27,
     EMaterialFlags_HasShadowMap     = 1 << 28,
-    EMaterialFlags_Flag20000000Crash= 1 << 29,
-    EMaterialFlags_Flag40000000     = 1 << 30,
-    EMaterialFlags_Flag80000000     = 1u << 31
+    EMaterialFlags_Bit29            = 1 << 29,
+    EMaterialFlags_Bit30            = 1 << 30,
+    EMaterialFlags_Bit31            = 1 << 31
 } EMaterialFlags;
 
 typedef enum<u32>
@@ -134,7 +140,7 @@ typedef enum<u8>
 typedef enum<u32>
 {
     EMaterialAttributeType_ToonShading = 0,
-    EMaterialAttributeType_Type1 = 1,
+    EMaterialAttributeType_InnerGlow = 1,
     EMaterialAttributeType_Outline = 2,
     EMaterialAttributeType_Type3 = 3,
     EMaterialAttributeType_Type4 = 4,
@@ -159,11 +165,11 @@ typedef enum<u32>
 
 typedef enum<u32>
 {
-    EMaterialAttributeType1Flags_Bit0 = 1 << 0,
-    EMaterialAttributeType1Flags_Bit1 = 1 << 1,
-    EMaterialAttributeType1Flags_Bit2 = 1 << 2,
-    EMaterialAttributeType1Flags_Bit3 = 1 << 3,
-} EMaterialAttributeType1Flags;
+    EMaterialAttributeInnerGlowFlags_Bit0 = 1 << 0,
+    EMaterialAttributeInnerGlowFlags_Bit1 = 1 << 1,
+    EMaterialAttributeInnerGlowFlags_Bit2 = 1 << 2,
+    EMaterialAttributeInnerGlowFlags_Bit3 = 1 << 3,
+} EMaterialAttributeInnerGlowFlags;
 
 typedef enum<u32>
 {


### PR DESCRIPTION
i feel like we should comment out the cfb byte check in favor of p5r (which uses the same version and doesnt have the padding byte)
like who touches cfb, most people use the template for p5r
if you would want to use it with cfb then just uncomment the byte check